### PR TITLE
Add StringNode class

### DIFF
--- a/src/class/json/StringNode.hpp
+++ b/src/class/json/StringNode.hpp
@@ -1,0 +1,24 @@
+#ifndef STRING_NODE_H
+#define STRING_NODE_H
+
+#include "ValueNodeBase.hpp"
+
+namespace JSON {
+    class StringNode : public ValueNodeBase {
+        const Type type;
+        const std::unique_ptr<std::string> value;
+
+    public:
+        StringNode(std::string&& s) : type(Type::String), value(std::make_unique<std::string>(std::move(s))) {}
+
+        Type getType() const override {
+            return type;
+        }
+
+        void* getValue() const override {
+            return value.get();
+        }
+    };
+}
+
+#endif // STRING_NODE_H

--- a/src/class/json/ValueNodeBase.hpp
+++ b/src/class/json/ValueNodeBase.hpp
@@ -13,7 +13,8 @@ namespace JSON {
         Boolean,
         Empty,
         Null,
-        Number
+        Number,
+        String
     };
 
     class ValueNodeBase {

--- a/test/Makefile
+++ b/test/Makefile
@@ -13,6 +13,7 @@ build:
 	${SRC_DIR}/class/BooleanNode.test.cpp \
 	${SRC_DIR}/class/NullNode.test.cpp \
 	${SRC_DIR}/class/NumberNode.test.cpp \
+	${SRC_DIR}/class/StringNode.test.cpp \
 	${SRC_DIR}/class/ValueNodeBase.test.cpp \
 	${SRC_DIR}/run.cpp \
 	$^ $(DEBUG_FLAGS) \

--- a/test/src/class/BooleanNode.test.cpp
+++ b/test/src/class/BooleanNode.test.cpp
@@ -7,7 +7,7 @@ namespace BooleanNodeTests {
     void init() {
         tests.add({ "JSON::BooleanNode class tests" });
 
-        tests.add({ "JSON::BooleanNode::getType() returns Type::BooleanNode enum value", [](){
+        tests.add({ "JSON::BooleanNode::getType() returns Type::Boolean enum value", [](){
             const auto instance = JSON::BooleanNode(false);
             if (instance.getType() != JSON::Type::Boolean) {
                 return false;

--- a/test/src/class/NullNode.test.cpp
+++ b/test/src/class/NullNode.test.cpp
@@ -7,7 +7,7 @@ namespace NullNodeTests {
     void init() {
         tests.add({ "JSON::NullNode class tests" });
 
-        tests.add({ "JSON::NullNode::getType() returns Type::NullNode enum value", [](){
+        tests.add({ "JSON::NullNode::getType() returns Type::Null enum value", [](){
             const auto instance = JSON::NullNode();
             if (instance.getType() != JSON::Type::Null) {
                 return false;

--- a/test/src/class/NumberNode.test.cpp
+++ b/test/src/class/NumberNode.test.cpp
@@ -7,7 +7,7 @@ namespace NumberNodeTests {
     void init() {
         tests.add({ "JSON::NumberNode class tests" });
 
-        tests.add({ "JSON::NumberNode::getType() returns Type::NumberNode enum value", [](){
+        tests.add({ "JSON::NumberNode::getType() returns Type::Number enum value", [](){
             const auto instance = JSON::NumberNode(0);
             if (instance.getType() != JSON::Type::Number) {
                 return false;

--- a/test/src/class/StringNode.test.cpp
+++ b/test/src/class/StringNode.test.cpp
@@ -1,0 +1,49 @@
+#include "../../../src/class/json/StringNode.hpp"
+#include "StringNode.test.hpp"
+
+namespace StringNodeTests {
+    Test::TestGroup tests{};
+
+    void init() {
+        tests.add({ "JSON::StringNode class tests" });
+
+        tests.add({ "JSON::StringNode::getType() returns Type::String enum value", [](){
+            auto v = std::string("");
+            const auto instance = JSON::StringNode(std::move(v));
+            if (instance.getType() != JSON::Type::String) {
+                return false;
+            }
+
+            return true;
+        }});
+
+        tests.add({ "JSON::StringNode::getValue() returns pointer to std::string = \"\" when constructor given \"\"", [](){
+            auto v = std::string("");
+            const auto instance = JSON::StringNode(std::move(v));
+
+            auto strPtr = static_cast<std::string*>(instance.getValue());
+            if (*(strPtr) != v) {
+                return false;
+            }
+
+            return true;
+        }});
+
+        tests.add({ "JSON::StringNode::getValue() moves string contents from given std::string object to self on construction", [](){
+            const char* message = "potato pancakes";
+            auto v = std::string(message);
+
+            const auto instance = JSON::StringNode(std::move(v));
+            auto strPtr = static_cast<std::string*>(instance.getValue());
+            if (*(strPtr) != message) {
+                return false;
+            }
+
+            if (!v.empty()) {
+                return false; // verify storage ownership was moved to new owner
+            }
+
+            return true;
+        }});
+    }
+}

--- a/test/src/class/StringNode.test.hpp
+++ b/test/src/class/StringNode.test.hpp
@@ -1,0 +1,11 @@
+#ifndef STRING_NODE_TESTS_H
+#define STRING_NODE_TESTS_H
+
+#include "../../../src/class/test/TestRunner.hpp"
+
+namespace StringNodeTests {
+    extern Test::TestGroup tests;
+    void init();
+}
+
+#endif // STRING_NODE_TESTS_H

--- a/test/src/run.cpp
+++ b/test/src/run.cpp
@@ -2,6 +2,7 @@
 #include "class/BooleanNode.test.hpp"
 #include "class/NullNode.test.hpp"
 #include "class/NumberNode.test.hpp"
+#include "class/StringNode.test.hpp"
 
 int main(void) {
     Test::TestRunner tr = Test::TestRunner();
@@ -17,6 +18,9 @@ int main(void) {
 
     NumberNodeTests::init();
     tr.add(NumberNodeTests::tests);
+
+    StringNodeTests::init();
+    tr.add(StringNodeTests::tests);
 
     tr.run();
 }


### PR DESCRIPTION
* Fixed some test messages
* Add StringNode class and constructor which, hopefully, passes ownership of provided std::string instance to the std::unique_ptr within the class
* Add test to ensure new StringNodes have a Type of String
* Add test to make sure move semantics are properly used to prevent std::string copying on StringNode constuction