### PR TITLE
Fix Bugs and Make Code Easier to Read Here and There

### DIFF
--- a/src/class/json/Parser.cpp
+++ b/src/class/json/Parser.cpp
@@ -100,8 +100,9 @@ namespace JSON {
 
     // top of stack has an open Object or complete key-value pair
     bool Parser::readyForObjectKey() const {
-        return stack.top().isKeyValuePair()
-            || stack.top().isOpenObject();
+        return (stack.top().isKeyValuePair()
+            || stack.top().isOpenObject())
+            && !stack.top().isOpenArray();
     }
 
     bool Parser::expectingKey() const {
@@ -280,6 +281,7 @@ namespace JSON {
 
                 break;
             case '-':
+            case '+':
             case '.':
             case '0':
             case '1':

--- a/test/src/class/json/Parser.test.cpp
+++ b/test/src/class/json/Parser.test.cpp
@@ -34,6 +34,7 @@ std::vector<numberTestRow> numberTestrows{
     { "10..0",  0,     SHOULD_THROW },
     { "10.01",  10.01               },
     { "10e12",  10e12               },
+    { "10e+12",  10e+12             },
     { "123.45", 123.45              },
     { "12345",  12345               },
     { "1e",     0,     SHOULD_THROW },
@@ -139,6 +140,21 @@ namespace ParserTests {
         } });
 
         tests.add({ "JSON::Parser::parse(): Object" });
+
+        tests.add({ "correctly parses {\"object with 1 member\":[\"array with 1 element\"]}", [](){
+            std::stringstream sstream(R"({"object with 1 member":["array with 1 element"]})");
+            auto json = JSON::Parser().parse(sstream);
+
+            auto vector = JSON::ArrayStorageType();
+            vector.push_back(std::make_unique<JSON::StringNode>("array with 1 element"));
+
+            JSON::ObjectStorageType map;
+            map.emplace("object with 1 member", std::make_unique<JSON::ArrayNode>(std::move(vector)));
+
+            return json == Test::createJSON<JSON::ObjectNode>(map);
+        }});
+
+
         tests.add({ "correctly parses {\"emptyMsg\": \"\"}", [](){
             std::stringstream sstream(R"({"emptyMsg": ""})");
             auto json = JSON::Parser().parse(sstream);


### PR DESCRIPTION
* UTF-8 substring validation
* Fixed escape sequence handling
* Add some newlines to make code more readable
* All test payloads provided here yield the expected result: http://www.json.org/JSON_checker/test.zip
* Fixed `+` in numbers in exponent notation being not allowed
* Removed some redundant validation checks and control flow
* Added escaped `/` allowance
* Replaced `auto` with actual `unique_ptr` types where it makes the code more easily understandable
* Added a unit test for exponent notation with `+` and explicit test for objects with a singleton array as a value, fixing a bug I somehow missed